### PR TITLE
fix: Do not override GITHUB_TOKEN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
 | model          | String | Optional, the model used for code review, defaults to `deepseek-chat`   |
 | base-url       | String | Optional, Deepseek API Base URL, defaults to `https://api.deepseek.com` |
 | sys-prompt     | String | Optional, system prompt corresponding to `$sys_prompt` in the input, default value see note below |
-| user-prompt    | String | Optional, system prompt corresponding to `$user_prompt` in the input, default value see note below |
+| user-prompt    | String | Optional, user prompt corresponding to `$user_prompt` in the input, default value see note below |
 
 **API Call Input**:
 

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -53,7 +53,6 @@ export def deepseek-review [
     $'🚀 Initiate the code review by Deepseek AI for PR (ansi g)#($pr_number)(ansi reset) in (ansi g)($repo)(ansi reset) ...'
   }
   print $hint; print -n (char nl)
-  $env.GITHUB_TOKEN = $gh_token | default $env.GITHUB_TOKEN?
   let diff_content = if ($pr_number | is-not-empty) {
       gh pr diff $pr_number --repo $repo | str trim
     } else if ($diff_from | is-not-empty) {


### PR DESCRIPTION
fix: Do not override GITHUB_TOKEN env var, fixes #27 