### PR TITLE
deps: Upgrade Nushell to v0.102

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
     - name: Setup Nu
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.101.0
+        version: 0.102.0
 
     - name: DeepSeek Code Review
       shell: nu {0}


### PR DESCRIPTION
deps: Upgrade Nushell to v0.102, closes #75 