### PR TITLE
feat: Add support for custom patch commands in local code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Flags:
   -k, --gh-token <string>: Your GitHub token, fallback to GITHUB_TOKEN env var
   -t, --diff-to <string>: Diff to git REF
   -f, --diff-from <string>: Diff from git REF
+  -c, --patch-cmd <string>: The `git show` or `git diff` command to get the diff content, for local CR only
   -l, --max-length <int>: Maximum length of the content for review, 0 means no limit.
   -m, --model <string>: Model name, or read from CHAT_MODEL env var, `deepseek-chat` by default
   -b, --base-url <string>: DeepSeek API base URL, fallback to BASE_URL env var
@@ -197,6 +198,13 @@ nu cr
 nu cr --diff-from f536acc
 # Perform code review on the `git diff f536acc 0dd0eb5` changes in the local DEFAULT_LOCAL_REPO repo
 nu cr --diff-from f536acc --diff-to 0dd0eb5
+# Review the changes in the local `DEFAULT_LOCAL_REPO` repo using the `--patch-cmd` flag
+nu cr --patch-cmd 'git diff head~3'
+nu cr -c 'git show head~3'
+nu cr -c 'git diff 2393375 71f5a31'
+nu cr -c 'git diff 2393375 71f5a31 nu/*'
+nu cr -c 'git diff 2393375 71f5a31 :!nu/*'
+nu cr -c 'git diff --since=2025-02-09 HEAD'
 # Perform code review on PR #31 in the remote DEFAULT_GITHUB_REPO repo
 nu cr --pr-number 31
 # Perform code review on PR #31 in the remote hustcer/deepseek-review repo

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -160,6 +160,7 @@ Flags:
   -k, --gh-token <string>: Your GitHub token, fallback to GITHUB_TOKEN env var
   -t, --diff-to <string>: Diff to git REF
   -f, --diff-from <string>: Diff from git REF
+  -c, --patch-cmd <string>: The `git show` or `git diff` command to get the diff content, for local CR only
   -l, --max-length <int>: Maximum length of the content for review, 0 means no limit.
   -m, --model <string>: Model name, or read from CHAT_MODEL env var, `deepseek-chat` by default
   -b, --base-url <string>: DeepSeek API base URL, fallback to BASE_URL env var
@@ -193,6 +194,13 @@ nu cr
 nu cr --diff-from f536acc
 # 对本地 DEFAULT_LOCAL_REPO 仓库 `git diff f536acc 0dd0eb5` 修改内容进行代码审查
 nu cr --diff-from f536acc --diff-to 0dd0eb5
+# 通过 --patch-cmd 参数对本地 DEFAULT_LOCAL_REPO 仓库变更内容进行审查
+nu cr --patch-cmd 'git diff head~3'
+nu cr -c 'git show head~3'
+nu cr -c 'git diff 2393375 71f5a31'
+nu cr -c 'git diff 2393375 71f5a31 nu/*'
+nu cr -c 'git diff 2393375 71f5a31 :!nu/*'
+nu cr -c 'git diff --since=2025-02-09 HEAD'
 # 对远程 DEFAULT_GITHUB_REPO 仓库编号为 31 的 PR 进行代码审查
 nu cr --pr-number 31
 # 对远程 hustcer/deepseek-review 仓库编号为 31 的 PR 进行代码审查

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -185,7 +185,7 @@ def streaming-output [
         if $line == $RESPONSE_END { return }
         if ($line | is-empty) { return }
         let $last = $line | str substring 6.. | from json
-        if ($last | describe) =~ 'string' { print $last; return }
+        if $last == '-alive' { print $last; return }
         if $debug { $last | to json | save -rf $LAST_REPLY_TMP }
         $last | get choices.0.delta | if ($in | is-not-empty) { print -n $in.content }
       }

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -430,4 +430,66 @@ export def compare-ver [v1: string, v2: string] {
   0
 }
 
+# Check if the git command is safe to run in the shell
+# Validate command examples:
+#  - git show
+#  - git diff
+#  - git show head~1
+#  - git diff --since=2025-02-09 HEAD
+#  - git diff 2393375 71f5a31
+#  - git diff 2393375 71f5a31 nu/*
+#  - git diff 2393375 71f5a31 :!nu/*
+export def is-safe-git [cmd: string] {
+  # Normalize the command string by trimming and converting to lowercase
+  let normalized_cmd = ($cmd | str trim | str downcase)
+
+  # More strict regex for git commands, allow:
+  # 1. --since parameter with ISO date format
+  # 2. File path patterns with or without colon (e.g. :!nu/*, nu/*)
+  let allowed_regex = '^git\s+(show|diff)(?:\s+(?:--since=\d{4}-\d{2}-\d{2}|[a-zA-Z0-9_\-\.~/]+))*(?:\s+(?::[!]?)?[a-zA-Z0-9_\-\.\*\/]+)?$'
+
+  # Dangerous patterns to check (expanded list)
+  let dangerous_patterns = [
+    # Command chaining/injection
+    ';', '&&', '||', '|',
+    # Shell expansion
+    '?', '[', ']', '{', '}',
+    # Command substitution
+    '`', '$(',
+    # IO redirection
+    '>', '>>', '<', '<<',
+    # Special characters
+    '\n', '\r', '\t',
+    # Path traversal
+    '..',
+    # Environment variables
+    '$', '%',
+    # Quotes that might be used for injection
+    '"', "'"
+  ]
+
+  # First check: Command must match the allowed pattern
+  if ($normalized_cmd | find -r $allowed_regex | is-empty) {
+    print $'ERROR: Invalid git command format. (ansi r)Only simple `git show` or `git diff` commands are allowed(ansi reset).'
+    return false
+  }
+
+  # Second check: No dangerous patterns allowed
+  for pattern in $dangerous_patterns {
+    if ($cmd | str contains $pattern) {
+      print $'(ansi r)ERROR: Dangerous pattern detected: `($pattern)`(ansi reset)'
+      return false
+    }
+  }
+
+  # Third check: Command parts validation (increased limit to accommodate path patterns)
+  let cmd_parts = $normalized_cmd | split row ' '
+  if ($cmd_parts | length) > 6 {
+    print $'ERROR: Command too complex. (ansi r)Only simple `git show` or `git diff` commands are allowed(ansi reset).'
+    return false
+  }
+
+  true
+}
+
 alias main = deepseek-review


### PR DESCRIPTION
feat: Add support for custom patch commands in local code review, fixes #105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line option (`--patch-cmd`) that lets users specify a custom command for retrieving diff content during local code reviews.
  
- **Documentation**
  - Updated both English and Chinese guides with clear, practical examples of how to use the new option, ensuring enhanced usability for reviewing code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->