### PR TITLE
perf: Save the last reply of the model in memory instead of a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .env
 .env.dev
 .env.local
-.last-reply.json
 config.yml
 prompts.yaml

--- a/cspell.yml
+++ b/cspell.yml
@@ -6,6 +6,8 @@
 words:
 - psql
 - MPFR
+- nuon
+- nuons
 - ECODE
 - endfor
 - dotenv

--- a/nu/kv.nu
+++ b/nu/kv.nu
@@ -1,0 +1,187 @@
+# NOTE: This file was copied from https://github.com/nushell/nushell/tree/main/crates/nu-std/std-rfc/kv
+# And will be removed after the Nu v0.103 release
+# More examples could be found here: https://github.com/nushell/nushell/discussions/14965
+#
+# kv module
+#
+# use std-rfc/kv *
+#
+# Easily store and retrieve key-value pairs
+# in a pipeline.
+#
+# A common request is to be able to assign a
+# pipeline result to a variable. While it's
+# not currently possible to use a "let" statement
+# within a pipeline, this module provides an
+# alternative. Think of each key as a variable
+# that can be set and retrieved.
+
+# Stores the pipeline value for later use
+#
+# If the key already exists, it is updated to the new value provided.
+export def "kv set" [
+  key: string
+  value_or_closure?: any
+  --return (-r): string   # Whether and what to return to the pipeline output
+  --universal (-u)
+] {
+  # Pipeline input is preferred, but prioritize
+  # parameter if present. This allows $in to be
+  # used in the parameter if needed.
+  let input = $in
+
+  # If passed a closure, execute it
+  let arg_type = ($value_or_closure | describe)
+  let value = match $arg_type {
+    closure => { $input | do $value_or_closure }
+    _ => ($value_or_closure | default $input)
+  }
+
+  # Store values as nuons for type-integrity
+  let kv_pair = {
+    session: ''   # Placeholder
+    key: $key
+    value: ($value | to nuon)
+  }
+
+  let db_open = (db_setup --universal=$universal)
+  try {
+    # Delete the existing key if it does exist
+    do $db_open | query db $"DELETE FROM std_kv_store WHERE key = '($key)'"
+  }
+
+  match $universal {
+    true  => { $kv_pair | into sqlite (universal_db_path) -t std_kv_store }
+    false => { $kv_pair | stor insert -t std_kv_store }
+  }
+
+  # The value that should be returned from `kv set`
+  # By default, this is the input to `kv set`, even if
+  # overridden by a positional parameter.
+  # This can also be:
+  # input: (Default) The pipeline input to `kv set`, even if
+  #        overridden by a positional parameter. `null` if no
+  #        pipeline input was used.
+  # ---
+  # value: If a positional parameter was used for the value, then
+  #        return it, otherwise return the input (whatever was set).
+  #        If the positional was a closure, return the result of the
+  #        closure on the pipeline input.
+  # ---
+  # all: The entire contents of the existing kv table are returned
+  match ($return | default 'input') {
+    'all' => (kv list --universal=$universal)
+    'a' => (kv list --universal=$universal)
+    'value' => $value
+    'v' => $value
+    'input' => $input
+    'in' => $input
+    'i' => $input
+    _  => {
+      error make {
+        msg: "Invalid --return option"
+        label: {
+          text: "Must be 'all'/'a', 'value'/'v', or 'input'/'in'/'i'"
+          span: (metadata $return).span
+        }
+      }
+    }
+  }
+}
+
+# Retrieves a stored value by key
+#
+# Counterpart of "kv set". Returns null if the key is not found.
+export def "kv get" [
+  key: string # Key of the kv-pair to retrieve
+  --universal (-u)
+] {
+  let db_open = (db_setup --universal=$universal)
+  do $db_open
+    # Hack to turn a SQLiteDatabase into a table
+  | $in.std_kv_store | wrap temp | get temp
+  | where key == $key
+    # Should only be one occurrence of each key in the stor
+  | get -i value.0
+  | match $in {
+      # Key not found
+      null => null
+      # Key found
+      _ => { from nuon }
+  }
+}
+
+# List the currently stored key-value pairs
+#
+# Returns results as the Nushell value rather than the stored nuon.
+export def "kv list" [
+  --universal (-u)
+] {
+  let db_open = (db_setup --universal=$universal)
+
+  do $db_open | $in.std_kv_store? | each {|kv_pair|
+    {
+      key: $kv_pair.key
+      value: ($kv_pair.value | from nuon )
+    }
+  }
+}
+
+# Returns and removes a key-value pair
+export def --env "kv drop" [
+  key: string   # Key of the kv-pair to drop
+  --universal (-u)
+] {
+  let db_open = (db_setup --universal=$universal)
+
+  let value = (kv get --universal=$universal $key)
+
+  try {
+    do $db_open
+      # Hack to turn a SQLiteDatabase into a table
+    | query db $"DELETE FROM std_kv_store WHERE key = '($key)'"
+  }
+
+  if $universal and ($env.NU_KV_UNIVERSALS? | default false) {
+    hide-env $key
+  }
+
+  $value
+}
+
+def universal_db_path [] {
+  $env.NU_UNIVERSAL_KV_PATH?
+  | default (
+      $nu.data-dir | path join "std_kv_variables.sqlite3"
+  )
+}
+
+def db_setup [
+  --universal
+] : nothing -> closure {
+  try {
+    match $universal {
+      true  => {
+        # Ensure universal sqlite db and table exists
+        let uuid = (random uuid)
+        let dummy_record = {
+          session: ''
+          key: $uuid
+          value: ''
+        }
+        $dummy_record | into sqlite (universal_db_path) -t std_kv_store
+        open (universal_db_path) | query db $"DELETE FROM std_kv_store WHERE key = '($uuid)'"
+      }
+      false => {
+        # Create the stor table if it doesn't exist
+        stor create -t std_kv_store -c {session: str, key: str, value: str} | ignore
+      }
+    }
+  }
+
+  # Return the correct closure for opening on-disk vs. in-memory
+  match $universal {
+    true  => {{|| open (universal_db_path)}}
+    false => {{|| stor open}}
+  }
+}

--- a/nu/kv.nu
+++ b/nu/kv.nu
@@ -47,7 +47,7 @@ export def "kv set" [
   let db_open = (db_setup --universal=$universal)
   try {
     # Delete the existing key if it does exist
-    do $db_open | query db $"DELETE FROM std_kv_store WHERE key = '($key)'"
+    do $db_open | query db "DELETE FROM std_kv_store WHERE key = :key" --params { key: $key }
   }
 
   match $universal {
@@ -139,7 +139,7 @@ export def --env "kv drop" [
   try {
     do $db_open
       # Hack to turn a SQLiteDatabase into a table
-    | query db $"DELETE FROM std_kv_store WHERE key = '($key)'"
+      | query db "DELETE FROM std_kv_store WHERE key = :key" --params { key: $key }
   }
 
   if $universal and ($env.NU_KV_UNIVERSALS? | default false) {
@@ -170,7 +170,7 @@ def db_setup [
           value: ''
         }
         $dummy_record | into sqlite (universal_db_path) -t std_kv_store
-        open (universal_db_path) | query db $"DELETE FROM std_kv_store WHERE key = '($uuid)'"
+        open (universal_db_path) | query db "DELETE FROM std_kv_store WHERE key = :key" --params { key: $uuid }
       }
       false => {
         # Create the stor table if it doesn't exist


### PR DESCRIPTION
perf: Save the last reply of the model in memory instead of a file, fixes #112 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a key-value data management interface for pipelines, enabling users to store, retrieve, list, and remove data directly in their sessions.

- **Refactor**
  - Streamlined debug operations by transitioning from file-based to in-memory handling, improving efficiency during debugging.

- **Chores**
  - Updated spell-check configurations with additional supported terms.
  - Made minor housekeeping adjustments for improved overall system operations.
  - Removed `.last-reply.json` from version control ignore list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->