### PR TITLE
fix: Fix include and exclude on GitHub Windows runners and related tests

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -7,6 +7,7 @@ words:
 - psql
 - MPFR
 - nuon
+- pwsh
 - nuons
 - ECODE
 - vyadh
@@ -24,4 +25,5 @@ words:
 - subshells
 - Infinigence
 - SILICONFLOW
+- USERPROFILE
 ignorePaths:

--- a/nu/common.nu
+++ b/nu/common.nu
@@ -16,6 +16,18 @@ export const ECODE = {
   CONDITION_NOT_SATISFIED: 8,
 }
 
+# If current host is Windows
+export def windows? [] {
+  # Windows / Darwin
+  (sys host | get name) == 'Windows'
+}
+
+# If current host is Windows
+export def mac? [] {
+  # Windows / Darwin
+  (sys host | get name) == 'Darwin'
+}
+
 # Compare two version number, return `1` if first one is higher than second one,
 # Return `0` if they are equal, otherwise return `-1`
 # Format: Expects semantic version strings (major.minor.patch)

--- a/nu/common.nu
+++ b/nu/common.nu
@@ -22,7 +22,7 @@ export def windows? [] {
   (sys host | get name) == 'Windows'
 }
 
-# If current host is Windows
+# If current host is macOS
 export def mac? [] {
   # Windows / Darwin
   (sys host | get name) == 'Darwin'

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -405,13 +405,15 @@ export def is-safe-git [cmd: string] {
 }
 
 # Setup scoop and install gawk for GitHub Windows runners
+# This command is essential for resolving the issue of simultaneously
+# applying include and exclude patterns on GitHub's Windows runners.
 def install-gawk-for-actions [] {
   # Install scoop using PowerShell
   pwsh -c "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')"
     | complete | get stdout | print
   # Add scoop to PATH and add main bucket
   pwsh -c '$env:Path = "$env:USERPROFILE\scoop\shims;" + $env:Path; scoop update; scoop install gawk'
-  gawk --version | lines | first
+  gawk --version | lines | first | print
   'gawk'
 }
 

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -410,9 +410,9 @@ def install-gawk-for-actions [] {
   pwsh -c "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')"
     | complete | get stdout | print
   # Add scoop to PATH and add main bucket
-  pwsh -c '$env:Path += ";$env:USERPROFILE\scoop\shims"; scoop update; scoop install gawk'
-  ^$'($nu.home-path)\scoop\shims\gawk.exe' --version | lines | first
-  $'($nu.home-path)\scoop\shims\gawk.exe'
+  pwsh -c '$env:Path = "$env:USERPROFILE\scoop\shims;" + $env:Path; scoop update; scoop install gawk'
+  gawk --version | lines | first
+  'gawk'
 }
 
 alias main = deepseek-review

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -408,6 +408,7 @@ export def is-safe-git [cmd: string] {
 def install-gawk-for-actions [] {
   # Install scoop using PowerShell
   pwsh -c "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')"
+    | complete | get stdout | print
   # Add scoop to PATH and add main bucket
   pwsh -c r#'
             $env:Path += ";$env:USERPROFILE\scoop\shims"

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -408,7 +408,6 @@ export def is-safe-git [cmd: string] {
 def install-gawk-for-actions [] {
   # Install scoop using PowerShell
   pwsh -c "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')"
-    | complete | get stdout | print
   # Add scoop to PATH and add main bucket
   pwsh -c r#'
             $env:Path += ";$env:USERPROFILE\scoop\shims"

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -410,10 +410,7 @@ def install-gawk-for-actions [] {
   pwsh -c "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')"
     | complete | get stdout | print
   # Add scoop to PATH and add main bucket
-  pwsh -c r#'
-            $env:Path += ";$env:USERPROFILE\scoop\shims"
-            scoop update; scoop install gawk
-          '#
+  pwsh -c '$env:Path += ";$env:USERPROFILE\scoop\shims"; scoop update; scoop install gawk'
   ^$'($nu.home-path)\scoop\shims\gawk.exe' --version | lines | first
   $'($nu.home-path)\scoop\shims\gawk.exe'
 }

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -411,11 +411,9 @@ def install-gawk-for-actions [] {
     | complete | get stdout | print
   # Add scoop to PATH and add main bucket
   pwsh -c r#'
-    $env:Path += ";$env:USERPROFILE\scoop\shims"
-    scoop bucket add main
-    scoop update
-    scoop install gawk
-  '#
+            $env:Path += ";$env:USERPROFILE\scoop\shims"
+            scoop update; scoop install gawk
+          '#
   ^$'($nu.home-path)\scoop\shims\gawk.exe' --version | lines | first
   $'($nu.home-path)\scoop\shims\gawk.exe'
 }

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -26,7 +26,7 @@
 #  - Local PR Review: just cr -r hustcer/deepseek-review -n 32
 
 use kv.nu *
-use common.nu [ECODE, hr-line, is-installed, git-check, has-ref, compare-ver, compact-record]
+use common.nu [ECODE, hr-line, is-installed, git-check, has-ref, compare-ver, compact-record, windows?, mac?]
 
 const RESPONSE_END = 'data: [DONE]'
 
@@ -297,9 +297,13 @@ export def prepare-awk [] {
   if $gawk_installed {
     let gawk_version = gawk --version | lines | first | split row , | first | split row ' ' | last
     print $'Current gawk version: ($gawk_version)'
-    if (compare-ver $gawk_version $MIN_GAWK_VERSION) >= 0 { return 'gawk' }
+    if (compare-ver $gawk_version $MIN_GAWK_VERSION) >= 0 {
+      return 'gawk'
+    } else if (windows?) and ($env.GITHUB_ACTIONS? == 'true') {
+      return (install-gawk-for-actions)
+    }
   }
-  if (sys host | get name) == 'Darwin' and (is-installed brew) {
+  if (mac?) and (is-installed brew) {
     brew install gawk
     print $'Current gawk version: (gawk --version | lines | first)'
     return 'gawk'
@@ -398,6 +402,22 @@ export def is-safe-git [cmd: string] {
   }
 
   true
+}
+
+# Setup scoop and install gawk for GitHub Windows runners
+def install-gawk-for-actions [] {
+  # Install scoop using PowerShell
+  pwsh -c "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')"
+    | complete | get stdout | print
+  # Add scoop to PATH and add main bucket
+  pwsh -c r#'
+    $env:Path += ";$env:USERPROFILE\scoop\shims"
+    scoop bucket add main
+    scoop update
+    scoop install gawk
+  '#
+  ^$'($nu.home-path)\scoop\shims\gawk.exe' --version | lines | first
+  $'($nu.home-path)\scoop\shims\gawk.exe'
 }
 
 alias main = deepseek-review

--- a/tests/test-review.nu
+++ b/tests/test-review.nu
@@ -3,6 +3,9 @@ use std/assert
 
 use ../nu/review.nu [is-safe-git, generate-include-regex, generate-exclude-regex, prepare-awk, get-diff]
 
+# Get the unicode width of the input string
+def get-uw [] { $in | str stats | get unicode-width }
+
 #[before-all]
 def setup [] {
   let awk_bin = (prepare-awk)
@@ -34,10 +37,6 @@ def 'is-safe-git：should work as expected' [] {
   assert equal (is-safe-git 'git diff f536acc 0dd0eb5 :!nu/* >> out.txt') false
   assert equal (is-safe-git 'git diff f536acc 0dd0eb5 :!nu/* < in.txt') false
   assert equal (is-safe-git 'git diff f536acc 0dd0eb5 :!nu/* << in.txt') false
-}
-
-def get-uw [] {
-  $in | str stats | get unicode-width
 }
 
 #[test]

--- a/tests/test-review.nu
+++ b/tests/test-review.nu
@@ -36,46 +36,46 @@ def 'is-safe-git：should work as expected' [] {
   assert equal (is-safe-git 'git diff f536acc 0dd0eb5 :!nu/* << in.txt') false
 }
 
+def get-uw [] {
+  $in | str stats | get unicode-width
+}
+
 #[test]
 def 'generate-include-regex：should work as expected' [] {
   let patch = $in.patch
   let awk_bin = $in.awk
-  assert equal ($patch | ^$awk_bin (generate-include-regex [*]) | length) 8133
-  assert equal ($patch | ^$awk_bin (generate-include-regex [nu/*]) | length) 2577
-  assert equal ($patch | ^$awk_bin (generate-include-regex [nu/*, **/*.yaml]) | length) 3670
-  assert equal ($patch | ^$awk_bin (generate-include-regex [.env*, *.md, nu/*]) | length) (7020 + 20)
+  assert equal ($patch | ^$awk_bin (generate-include-regex [*]) | get-uw) (7959 + 5)
+  assert equal ($patch | ^$awk_bin (generate-include-regex [nu/*]) | get-uw) 2576
+  assert equal ($patch | ^$awk_bin (generate-include-regex [nu/*, **/*.yaml]) | get-uw) 3669
+  assert equal ($patch | ^$awk_bin (generate-include-regex [.env*, *.md, nu/*]) | get-uw) 6871
 }
 
 #[test]
 def 'generate-exclude-regex：should work as expected' [] {
   let patch = $in.patch
   let awk_bin = $in.awk
-  assert equal ($patch | ^$awk_bin (generate-exclude-regex [*]) | length) 357
-  assert equal ($patch | ^$awk_bin (generate-exclude-regex [.env*, *.md, nu/*]) | length) (1350 + 100)
+  assert equal ($patch | ^$awk_bin (generate-exclude-regex [*]) | get-uw) 356
+  assert equal ($patch | ^$awk_bin (generate-exclude-regex [.env*, *.md, nu/*]) | get-uw) (1350 + 99)
 }
 
 #[test]
 def 'both include and exclude should work as expected' [] {
   let patch = $in.patch
   let awk_bin = $in.awk
-  # TODO: Fix the issue on Windows
-  if (sys host | get name) == 'Windows' { return }
   assert equal ($patch
     | ^$awk_bin (generate-include-regex [nu/*, **/*.yaml])
     | ^$awk_bin (generate-exclude-regex [**/*.yaml])
-    | length) 2577
+    | get-uw) 2576
 }
 
 #[test]
 def 'both exclude and include should work as expected' [] {
   let patch = $in.patch
   let awk_bin = $in.awk
-  # TODO: Fix the issue on Windows
-  if (sys host | get name) == 'Windows' { return }
   assert equal ($patch
     | ^$awk_bin (generate-exclude-regex [**/*.yaml])
     | ^$awk_bin (generate-include-regex [nu/*])
-    | length) 2577
+    | get-uw) 2576
 }
 
 #[test]
@@ -85,7 +85,7 @@ def 'get-diff：get patch from remote PR should work' [] {
   if ($env.GH_TOKEN | is-empty) { print '$env.GH_TOKEN is empty'; return }
   let patch = get-diff --pr-number 93 --repo $repo
   assert equal ($patch | lines | skip 1
-                  | str join "\n" | str stats | get unicode-width) 7923
+                  | str join "\n" | get-uw) 7923
 }
 
 #[test]
@@ -94,7 +94,7 @@ def 'get-diff：get patch from remote PR with include should work' [] {
   const repo = 'hustcer/deepseek-review'
   if ($env.GH_TOKEN | is-empty) { print '$env.GH_TOKEN is empty'; return }
   let patch = get-diff --pr-number 93 --repo $repo --include nu/*
-  assert equal ($patch | str stats | get unicode-width) 2576
+  assert equal ($patch | get-uw) 2576
 }
 
 #[test]
@@ -103,5 +103,5 @@ def 'get-diff：get patch from remote PR with exclude should work' [] {
   const repo = 'hustcer/deepseek-review'
   if ($env.GH_TOKEN | is-empty) { print '$env.GH_TOKEN is empty'; return }
   let patch = get-diff --pr-number 93 --repo $repo --exclude **/*.yaml,**/*.nu,*.md
-  assert equal ($patch | str stats | get unicode-width) 555
+  assert equal ($patch | get-uw) 555
 }


### PR DESCRIPTION
fix: Fix simultaneously applying `include` and `exclude` on GitHub Windows runners and related tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced operating system detection for Windows and macOS, enabling adaptive behavior.
  - Improved automation workflows with support for automatically installing essential tools on Windows environments.

- **Chores**
  - Updated spell-checker configuration with additional approved words.
  - Refined string width calculation for more consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->