### PR TITLE
feat: Add repo of current directory code review support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Usage:
 
 Flags:
   -d, --debug: Debug mode
-  -r, --repo <string>: GitHub repo name, e.g. hustcer/deepseek-review, or local repo path / alias
+  -r, --repo <string>: GitHub repo name, e.g. hustcer/deepseek-review
   -n, --pr-number <string>: GitHub PR number
   -k, --gh-token <string>: Your GitHub token, fallback to GITHUB_TOKEN env var
   -t, --diff-to <string>: Diff to git REF
@@ -211,13 +211,13 @@ To perform code reviews locally, you need to modify the configuration file. A sa
 ### Usage Examples
 
 ```sh
-# Perform code review on the `git diff` changes in the local DEFAULT_LOCAL_REPO repo
+# Perform code review on the `git diff` changes in current directory
 nu cr
-# Perform code review on the `git diff f536acc` changes in the local DEFAULT_LOCAL_REPO repo
+# Perform code review on the `git diff f536acc` changes in current directory
 nu cr --diff-from f536acc
-# Perform code review on the `git diff f536acc 0dd0eb5` changes in the local DEFAULT_LOCAL_REPO repo
+# Perform code review on the `git diff f536acc 0dd0eb5` changes in current directory
 nu cr --diff-from f536acc --diff-to 0dd0eb5
-# Review the changes in the local `DEFAULT_LOCAL_REPO` repo using the `--patch-cmd` flag
+# Review the changes in current directory using the `--patch-cmd` flag
 nu cr --patch-cmd 'git diff head~3'
 nu cr -c 'git show head~3'
 nu cr -c 'git diff 2393375 71f5a31'

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,7 +172,7 @@ Usage:
 
 Flags:
   -d, --debug: Debug mode
-  -r, --repo <string>: GitHub repo name, e.g. hustcer/deepseek-review, or local repo path / alias
+  -r, --repo <string>: GitHub repo name, e.g. hustcer/deepseek-review
   -n, --pr-number <string>: GitHub PR number
   -k, --gh-token <string>: Your GitHub token, fallback to GITHUB_TOKEN env var
   -t, --diff-to <string>: Diff to git REF
@@ -207,13 +207,13 @@ Parameters:
 ### 使用举例
 
 ```sh
-# 对本地 DEFAULT_LOCAL_REPO 仓库 `git diff` 修改内容进行代码审查
+# 对本地当前目录所在仓库 `git diff` 修改内容进行代码审查
 nu cr
-# 对本地 DEFAULT_LOCAL_REPO 仓库 `git diff f536acc` 修改内容进行代码审查
+# 对本地当前目录所在仓库 `git diff f536acc` 修改内容进行代码审查
 nu cr --diff-from f536acc
-# 对本地 DEFAULT_LOCAL_REPO 仓库 `git diff f536acc 0dd0eb5` 修改内容进行代码审查
+# 对本地当前目录所在仓库 `git diff f536acc 0dd0eb5` 修改内容进行代码审查
 nu cr --diff-from f536acc --diff-to 0dd0eb5
-# 通过 --patch-cmd 参数对本地 DEFAULT_LOCAL_REPO 仓库变更内容进行审查
+# 通过 --patch-cmd 参数对本地当前目录所在仓库变更内容进行审查
 nu cr --patch-cmd 'git diff head~3'
 nu cr -c 'git show head~3'
 nu cr -c 'git diff 2393375 71f5a31'

--- a/config.example.yml
+++ b/config.example.yml
@@ -27,8 +27,6 @@ settings:
   # This token is used to fetch the PR changes from GitHub API
   # Default value will be ${{ github.token }} if used in GitHub Actions
   github-token: 'YOUR_GITHUB_TOKEN'
-  # Default local repository to review, could be overrode by '-r' or '--repo'
-  default-local-repo: 'review'
   # Default GitHub repository to review, could be overrode by '-r' or '--repo' if used with `-n` or `--pr-number`
   default-github-repo: 'hustcer/deepseek-review'
   # Include changes in the following file patterns
@@ -71,17 +69,6 @@ providers:
       - name: 'deepseek-ai/DeepSeek-R1'
         alias: r1
         description: 'SiliconFlow DeepSeek R1 model'
-
-
-# Multiple local repositories could be defined, select the one by name in 'settings.default-local-repo'
-# You can also use `-r` or `--repo` to specify the local repository to review by name to override the default
-local-repos:
-  - name: 'review'
-    path: '/Users/hustcer/deepseek-review'
-  - name: 'milestone'
-    path: '/Users/hustcer/milestone-action'
-  - name: 'setup-nu'
-    path: '/Users/hustcer/setup-nu'
 
 # Multiple Prompts could be defined, select the one by name in 'settings.user-prompt' or 'settings.system-prompt'
 prompts:

--- a/cr
+++ b/cr
@@ -11,7 +11,7 @@ use nu/review.nu [deepseek-review]
 def main [
   token?: string,           # Your DeepSeek API token, fallback to CHAT_TOKEN env var
   --debug(-d),              # Debug mode
-  --repo(-r): string,       # GitHub repo name, e.g. hustcer/deepseek-review, or local repo path / alias
+  --repo(-r): string,       # GitHub repo name, e.g. hustcer/deepseek-review
   --pr-number(-n): string,  # GitHub PR number
   --gh-token(-k): string,   # Your GitHub token, fallback to GITHUB_TOKEN env var
   --diff-to(-t): string,    # Diff to git REF
@@ -31,7 +31,7 @@ def main [
 
   check-nushell
   config-check --config=$config
-  config-load --debug=$debug --config=$config --repo=$repo --model=$model
+  config-load --debug=$debug --config=$config --model=$model
   (
     deepseek-review $token
       --repo=$repo

--- a/nu/config.nu
+++ b/nu/config.nu
@@ -124,16 +124,10 @@ def get-model-envs [settings: record, model?: string = ''] {
 export def --env config-load [
   --debug(-d),                # Print the loaded environment variables
   --config(-C): string,       # The config file path, default to `config.yml`
-  --repo(-r): string,         # Load the specified local repository by name
   --model(-m): string,        # Load the specified model by name
 ] {
   let all_settings = open ($config | default $SETTING_FILE)
   let settings = $all_settings | get settings? | default {}
-  let local_repo = $all_settings.local-repos
-    | default []
-    | where name == ($repo | default $settings.default-local-repo? | default '')
-    | get -i 0.path
-    | default $repo
 
   let user_prompt = $all_settings.prompts?.user?
     | default []
@@ -156,7 +150,6 @@ export def --env config-load [
     GITHUB_TOKEN: $settings.github-token,
     EXCLUDE_PATTERNS: $settings.exclude-patterns,
     INCLUDE_PATTERNS: $settings.include-patterns,
-    DEFAULT_LOCAL_REPO: $local_repo,
     DEFAULT_GITHUB_REPO: $settings.default-github-repo,
   }
   load-env $env_vars

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -72,12 +72,12 @@ export def --env deepseek-review [
 ]: nothing -> nothing {
 
   $env.config.table.mode = 'psql'
+  let local_repo = (pwd)
   let is_action = ($env.GITHUB_ACTIONS? == 'true')
   let stream = if $is_action { false } else { true }
   let token = $token | default $env.CHAT_TOKEN?
   let repo = $repo | default $env.DEFAULT_GITHUB_REPO?
   let CHAT_HEADER = [Authorization $'Bearer ($token)']
-  let local_repo = $env.DEFAULT_LOCAL_REPO? | default (pwd)
   let model = $model | default $env.CHAT_MODEL? | default $DEFAULT_OPTIONS.MODEL
   let base_url = $base_url | default $env.BASE_URL? | default $DEFAULT_OPTIONS.BASE_URL
   let url = $chat_url | default $env.CHAT_URL? | default $'($base_url)/chat/completions'
@@ -257,16 +257,9 @@ export def get-diff [
   --exclude: string,    # Comma separated file patterns to exclude in the code review
   --patch-cmd: string,  # The `git show` or `git diff` command to get the diff content
 ] {
+  let local_repo = (pwd)
   let BASE_HEADER = [Authorization $'Bearer ($env.GH_TOKEN)' Accept application/vnd.github.v3+json]
   let DIFF_HEADER = [Authorization $'Bearer ($env.GH_TOKEN)' Accept application/vnd.github.v3.diff]
-  let local_repo = $env.DEFAULT_LOCAL_REPO? | default (pwd)
-  if ($pr_number | is-empty) {
-    if not ($local_repo | path exists) {
-      print $'(ansi r)The directory ($local_repo) does not exist.(ansi reset)'
-      exit $ECODE.CONDITION_NOT_SATISFIED
-    }
-    cd $local_repo
-  }
   mut content = if ($pr_number | is-not-empty) {
     if ($repo | is-empty) {
       print $'(ansi r)Please provide the GitHub repository name by `--repo` option.(ansi reset)'

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -72,7 +72,7 @@ export def --env deepseek-review [
 ]: nothing -> nothing {
 
   $env.config.table.mode = 'psql'
-  let local_repo = (pwd)
+  let local_repo = $env.PWD
   let is_action = ($env.GITHUB_ACTIONS? == 'true')
   let stream = if $is_action { false } else { true }
   let token = $token | default $env.CHAT_TOKEN?
@@ -257,7 +257,7 @@ export def get-diff [
   --exclude: string,    # Comma separated file patterns to exclude in the code review
   --patch-cmd: string,  # The `git show` or `git diff` command to get the diff content
 ] {
-  let local_repo = (pwd)
+  let local_repo = $env.PWD
   let BASE_HEADER = [Authorization $'Bearer ($env.GH_TOKEN)' Accept application/vnd.github.v3+json]
   let DIFF_HEADER = [Authorization $'Bearer ($env.GH_TOKEN)' Accept application/vnd.github.v3.diff]
   mut content = if ($pr_number | is-not-empty) {


### PR DESCRIPTION
feat: Add repo of current directory code review support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage instructions for the command-line interface. The **--repo** flag now accepts only GitHub repository names, and examples reference the current working directory.

- **Chores**
  - Removed local repository settings from the configuration example to simplify setup.

- **Refactor**
  - Streamlined repository handling by consistently using the current directory without extra validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->