### PR TITLE
[RR] Add Trigger for Skipping CR

### DIFF
--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -8,6 +8,8 @@ use util.nu [generate-include-regex, generate-exclude-regex, prepare-awk, is-saf
 
 # If the PR title or body contains any of these keywords, skip the review
 const IGNORE_REVIEW_KEYWORDS = ['skip review' 'skip cr']
+# If the latest PR commit message contains any of these keywords, skip the review
+const IGNORE_COMMIT_KEYWORDS = ['skip cr']
 
 # Get the diff content from GitHub PR or local git changes and apply filters
 export def get-diff [
@@ -77,6 +79,13 @@ def get-pr-diff [
   # Check if the PR title or body contains keywords to skip the review
   if ($IGNORE_REVIEW_KEYWORDS | any {|it| $description =~ $it }) {
     print $'(ansi r)The PR title or body contains keywords to skip the review, bye...(ansi reset)'
+    exit $ECODE.SUCCESS
+  }
+
+  let commit_msg = http get -H $BASE_HEADER $'($GITHUB_API_BASE)/repos/($repo)/pulls/($pr_number)/commits?per_page=1'
+                   | first | get commit.message
+  if ($IGNORE_COMMIT_KEYWORDS | any {|it| $commit_msg =~ $it }) {
+    print $'(ansi r)The latest PR commit message contains keywords to skip the review, bye...(ansi reset)'
     exit $ECODE.SUCCESS
   }
 

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -9,7 +9,6 @@ use util.nu [generate-include-regex, generate-exclude-regex, prepare-awk, is-saf
 # If the PR title or body contains any of these keywords, skip the review
 const IGNORE_REVIEW_KEYWORDS = ['skip review' 'skip cr']
 # If the latest PR commit message contains any of these keywords, skip the review
-const IGNORE_COMMIT_KEYWORDS = ['skip cr']
 
 # Get the diff content from GitHub PR or local git changes and apply filters
 export def get-diff [
@@ -82,9 +81,9 @@ def get-pr-diff [
     exit $ECODE.SUCCESS
   }
 
-  let commit_msg = http get -H $BASE_HEADER $'($GITHUB_API_BASE)/repos/($repo)/pulls/($pr_number)/commits?per_page=1'
-                   | first | get commit.message
-  if ($IGNORE_COMMIT_KEYWORDS | any {|it| $commit_msg =~ $it }) {
+  let commit_msg = http get -H $BASE_HEADER $'($GITHUB_API_BASE)/repos/($repo)/pulls/($pr_number)/commits'
+                   | last | get commit.message
+  if ($IGNORE_REVIEW_KEYWORDS | any {|it| $commit_msg =~ $it }) {
     print $'(ansi r)The latest PR commit message contains keywords to skip the review, bye...(ansi reset)'
     exit $ECODE.SUCCESS
   }

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -8,7 +8,6 @@ use util.nu [generate-include-regex, generate-exclude-regex, prepare-awk, is-saf
 
 # If the PR title or body contains any of these keywords, skip the review
 const IGNORE_REVIEW_KEYWORDS = ['skip review' 'skip cr']
-# If the latest PR commit message contains any of these keywords, skip the review
 
 # Get the diff content from GitHub PR or local git changes and apply filters
 export def get-diff [


### PR DESCRIPTION
This PR updates the code review workflow to let you skip the AI review when it isn't needed.
Resolves #134 

### Key Changes
*   **Skip Command**: Added a check that looks for the phrase "skip cr" in your latest commit message in the .nu file.

This can be skipped with `[skip ci]`, only CR will be skipped with `skip cr` and `skip review`, aligned with the first constant