### PR TITLE
Add Endpoint Format Checking

### DIFF
--- a/nu/review.nu
+++ b/nu/review.nu
@@ -83,7 +83,7 @@ export def --env deepseek-review [
   let model = $model | default $env.CHAT_MODEL? | default $DEFAULT_OPTIONS.MODEL
   let base_url = $base_url | default $env.BASE_URL? | default $DEFAULT_OPTIONS.BASE_URL
   let url = $chat_url | default $env.CHAT_URL? | default $'($base_url)/chat/completions'
-  if ($url | str downcase | str contains 'anthropic') and $is_action {
+  if ($url | str contains --ignore-case 'anthropic') and $is_action {
     print $'(ansi r)The endpoint URL contains "anthropic" — this action only supports OpenAI-format APIs. Aborting.(ansi reset)'
     exit $ECODE.INVALID_PARAMETER
   }

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -83,6 +83,10 @@ export def --env deepseek-review [
   let model = $model | default $env.CHAT_MODEL? | default $DEFAULT_OPTIONS.MODEL
   let base_url = $base_url | default $env.BASE_URL? | default $DEFAULT_OPTIONS.BASE_URL
   let url = $chat_url | default $env.CHAT_URL? | default $'($base_url)/chat/completions'
+  if ($url | str downcase | str contains 'anthropic') and $is_action {
+    print $'(ansi r)The endpoint URL contains "anthropic" — this action only supports OpenAI-format APIs. Aborting.(ansi reset)'
+    exit $ECODE.INVALID_PARAMETER
+  }
   let max_length = try { $max_length | default ($env.MAX_LENGTH? | default 0 | into int) } catch { 0 }
   let temperature = try { $temperature | default $env.TEMPERATURE? | default $DEFAULT_OPTIONS.TEMPERATURE | into float } catch { $DEFAULT_OPTIONS.TEMPERATURE }
   # Determine output mode


### PR DESCRIPTION
Added a small check, just to point out if users inputted a endpoint like `https://api.deepseek.com/anthropic`, which is certainly not a OPENAI endpoint.