### PR TITLE
deps: Update git-cliff version to 2.13.1 in configuration

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Nu
-      uses: hustcer/setup-nu@v3.23
+      uses: hustcer/setup-nu@v3
       with:
         version: 0.112.2
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,4 +1,4 @@
-# configuration file for git-cliff (0.1.0)
+# configuration file for git-cliff (2.13.1)
 
 [changelog]
 # changelog header


### PR DESCRIPTION
Updated the git-cliff file to the newest version.
Also aligned the setup-nu action version format in action.yml and test.yml.