### PR TITLE
No HB hints

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: macos-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     # Make sure the code review happens only when the PR has the label 'ai review'
     # if: contains(github.event.pull_request.labels.*.name, 'ai review')

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     steps:
       - name: DeepSeek Code Review
@@ -103,6 +106,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     # Make sure the code review happens only when the PR has the label 'ai review'
     if: contains(github.event.pull_request.labels.*.name, 'ai review')
@@ -137,6 +143,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     steps:
       - name: DeepSeek Code Review

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     steps:
       - name: DeepSeek Code Review
@@ -101,6 +104,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     # Make sure the code review happens only when the PR has the label 'ai review'
     if: contains(github.event.pull_request.labels.*.name, 'ai review')
@@ -135,6 +141,9 @@ permissions:
 jobs:
   setup-deepseek-review:
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_ASK: "0"
+      HOMEBREW_NO_ENV_HINTS: "1"
     name: Code Review
     steps:
       - name: DeepSeek Code Review

--- a/action.yaml
+++ b/action.yaml
@@ -73,8 +73,6 @@ runs:
     - name: DeepSeek Code Review
       shell: nu {0}
       env:
-        HOMEBREW_NO_ENV_HINTS: "1"
-        HOMEBREW_ASK: "0"
         WATCH_MENTION: ${{ inputs.watch-mention }}
       run: |
         const NU_LIB_DIRS = [ ${{ github.action_path }}/nu ]

--- a/action.yaml
+++ b/action.yaml
@@ -73,6 +73,8 @@ runs:
     - name: DeepSeek Code Review
       shell: nu {0}
       env:
+        HOMEBREW_NO_ENV_HINTS: "1"
+        HOMEBREW_ASK: "0"
         WATCH_MENTION: ${{ inputs.watch-mention }}
       run: |
         const NU_LIB_DIRS = [ ${{ github.action_path }}/nu ]


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow by adding environment variables to the `setup-deepseek-review` job. These variables configure Homebrew to run non-interactively and suppress environment hints, which helps streamline automated code review runs.