### PR TITLE
Align README files for consistency skip cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ jobs:
 - Every qualifying mention triggers a new review run; the results are submitted as a new review on the same PR.
 - Bot comments (users ending with `[bot]`) are ignored.
 - Comments on issues without an associated PR are ignored.
-  > [!NOTE]
-  > By default, only **COLLABORATORs, OWNER, MEMBERs can trigger the code review** by mentioning `@github-actions`.
-  > Other users without write access will be ignored.
-  > You can change this by appending or removing roles in `allowed-associations`. For example, if you want to enable contributors to trigger code reviews, set it as follows:
-  > `allowed-associations: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'`
+> [!NOTE]
+> By default, only **COLLABORATORs, OWNER, MEMBERs can trigger the code review** by mentioning `@github-actions`.
+> Other users without write access will be ignored.
+> You can change this by appending or removing roles in `allowed-associations`. For example, if you want to enable contributors to trigger code reviews, set it as follows:
+> `allowed-associations: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'`
 
 ## Input Parameters
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ jobs:
 - Bot comments (users ending with `[bot]`) are ignored.
 - Comments on issues without an associated PR are ignored.
 > [!NOTE]
-> By default, only **COLLABORATORs, OWNER, MEMBERs can trigger the code review** by mentioning `@github-actions`.
+> By default, only **COLLABORATORs, OWNER, MEMBERs can trigger the code review** by mentioning `$watch-mention`.
 > Other users without write access will be ignored.
-> You can change this by appending or removing roles in `allowed-associations`. For example, if you want to enable contributors to trigger code reviews, set it as follows:
+> You can change this by appending or removing roles in `$allowed-associations`. For example, if you want to enable contributors to trigger code reviews, set it as follows:
 > `allowed-associations: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'`
 
 ## Input Parameters

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -152,11 +152,11 @@ jobs:
 - 每次符合条件的提及都会触发一次新的审核，审核结果会以新的审查形式提交到同一个 PR 里。
 - 机器人评论 （结尾含有`[bot]`的用户的评论）会被忽略。
 - 没有关联 PR 的议题上的评论将被忽略。
-  > [!NOTE]
-  > 默认配置中，只有**COLLABORATORs, OWNER, MEMBERs 能通过提及`@github-actions`触发审查**。
-  > 其他没有写权限的用户的评论会被忽略。
-  > 您可以通过在 `allowed-associations` 中添加或移除角色来更改此设置。例如，如果您想允许贡献者触发代码审查，请按如下方式设置工作流：
-  > `allowed-associations: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'`
+> [!NOTE]
+> 默认配置中，只有**COLLABORATORs, OWNER, MEMBERs 能通过提及`$watch-mention`触发审查**。
+> 其他没有写权限的用户的评论会被忽略。
+> 您可以通过在 `$allowed-associations` 中添加或移除角色来更改此设置。例如，如果您想允许贡献者触发代码审查，请按如下方式设置工作流：
+> `allowed-associations: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'`
 
 ## 输入参数
 


### PR DESCRIPTION
之前: 
<img width="3096" height="1728" alt="Screenshot_20260602_200359" src="https://github.com/user-attachments/assets/f9002ef5-bccd-4395-a801-012bac9f59c6" />
现在:
<img width="3096" height="1727" alt="Screenshot_20260602_200510" src="https://github.com/user-attachments/assets/34535fa9-c04e-4b31-94c9-b10bbed7e520" />
