### PR TITLE
feat: skip code review on locked pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Allows interactive pull request author (must be included within `$allowed-associations`) to model conversation by appending a message after mentioning `$watch-mention` in a pull request comment.
 > [!WARNING]
 > Contents retrieved from a comment with `$watch-mention` has lower priority than `$sys-prompt`. Therefore, it might be overridden by `$sys-prompt` and ignored by model.
+- Automatically skip a review if the pull request conversation is locked.
 
 ### Local Code Review
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,7 @@
 - 支持通过在PR评论中提及`$watch-mention`实现互动性的PR作者（必须要归属于`$allowed-associations`）与模型之间的对话
 > [!WARNING]
 > 从提及`$watch-mention`的评论中检索到的内容优先级低于`$sys-prompt`。因此，它可能会被`$sys-prompt`覆盖，并被模型忽略。
+- 如果拉取请求对话被锁定，则自动跳过审查。
 
 ### 本地代码审查
 

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -172,7 +172,7 @@ export def --env deepseek-review [
   }
   $env.GH_TOKEN = $gh_token | default $env.GITHUB_TOKEN?
 
-  if ($pr_number | is-not-empty) and ($repo | is-not-empty) and (is-pr-locked $repo $pr_number) {
+  if $is_action and ($pr_number | is-not-empty) and ($repo | is-not-empty) and (is-pr-locked $repo $pr_number) {
     print $'(ansi y)PR #($pr_number) is locked, skipping review.(ansi reset)'
     exit $ECODE.SUCCESS
   }

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -88,6 +88,26 @@ def submit-review-to-pr [
   }
 }
 
+def is-pr-locked [
+  repo: string,
+  pr_number: string,
+] {
+  let url = $'($GITHUB_API_BASE)/repos/($repo)/pulls/($pr_number)'
+  let headers = [
+    Authorization $'Bearer ($env.GH_TOKEN)'
+    Accept application/vnd.github+json
+    X-GitHub-Api-Version '2022-11-28'
+    ...$HTTP_HEADERS
+  ]
+
+  try {
+    let response = http get -H $headers $url
+    ($response | get -o locked | default false)
+  } catch {
+    false
+  }
+}
+
 const DEFAULT_OPTIONS = {
   MODEL: 'deepseek-v4-flash',
   TEMPERATURE: 0.3,
@@ -151,6 +171,11 @@ export def --env deepseek-review [
     temperature: $temperature,
   }
   $env.GH_TOKEN = $gh_token | default $env.GITHUB_TOKEN?
+
+  if ($pr_number | is-not-empty) and ($repo | is-not-empty) and (is-pr-locked $repo $pr_number) {
+    print $'(ansi y)PR #($pr_number) is locked, skipping review.(ansi reset)'
+    exit $ECODE.SUCCESS
+  }
 
   validate-token $token --pr-number $pr_number --repo $repo
   let hint = if not $is_action and ($pr_number | is-empty) {


### PR DESCRIPTION
请看#221，下面的概述由copilot生成

This pull request improves the code review workflow by ensuring that the review process exits gracefully when a pull request's conversations are locked. It also updates the documentation to reflect this new behavior.

**Code review process improvements:**

* [`nu/review.nu`](diffhunk://#diff-8f3995aef815012056b48030e32b5354b01ac82ad95d0e37e4354b0c00c4e833R63-R69): Added a check to detect if a pull request is locked by querying the PR's metadata before attempting to post a review. If locked, the review process exits cleanly and prints a message.

**Documentation updates:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17): Added a note stating that code review exits cleanly on pull requests with conversations locked.
* [`README.zh-CN.md`](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987R15): Updated the Chinese documentation to mention the new behavior for locked pull requests.