### PR TITLE
fix: using external path in isolated docker containers

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -76,7 +76,7 @@ runs:
         WATCH_MENTION: ${{ inputs.watch-mention }}
         TEMPERATURE_INPUT: ${{ inputs.temperature }}
       run: |
-        const NU_LIB_DIRS = [ ${{ github.action_path }}/nu ]
+        const NU_LIB_DIRS = [ $env.GITHUB_ACTION_PATH/nu ]
         use review.nu *
         let model = '${{ inputs.model }}'
         let baseUrl = '${{ inputs.base-url }}'


### PR DESCRIPTION
请参考#223 
Copilot概述：
This pull request makes a small update to the `action.yaml` file to improve how the `NU_LIB_DIRS` variable is set. The change switches from using GitHub Actions' expression syntax to using the environment variable directly, which is more compatible with the Nu shell.

- Updated the assignment of `NU_LIB_DIRS` to use `$env.GITHUB_ACTION_PATH/nu` instead of `${{ github.action_path }}/nu` for better compatibility in the Nu shell.

Credits: G1Vh提出问题