### PR TITLE
Suppress Homebrew untrusted output in job logs

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -23,6 +23,8 @@ jobs:
     name: Code Review
     # Make sure the code review happens only when the PR has the label 'ai review'
     # if: contains(github.event.pull_request.labels.*.name, 'ai review')
+    env:
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: '1'
     steps:
       - name: DeepSeek Code Review
         uses: hustcer/deepseek-review@develop


### PR DESCRIPTION
macos-latest的runner景象预安装aws/tap，gawk和它没有关系，所以可以抑制输出