### PR TITLE
fix: nutest repo not found with `just test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 review.md
 config.yml
 prompts.yaml
+nutest/

--- a/Justfile
+++ b/Justfile
@@ -51,11 +51,11 @@ code-review *OPTIONS:
 
 # Run the test cases locally by nutest
 test:
-  @if not ('{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest", "nutest.nu") }}' | path exists) { \
+  @if not ('{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest", "mod.nu") }}' | path exists) { \
     print 'Cloning nutest ...'; \
     git clone --depth 1 https://github.com/vyadh/nutest.git '{{ join(DEEPSEEK_REVIEW_PATH, "nutest") }}' \
   }
-  @use '{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest", "nutest") }}' *; run-tests
+  @use '{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest") }}' *; run-tests --path tests
 
 # Plugins need to be registered only once after nu v0.61
 _setup:

--- a/Justfile
+++ b/Justfile
@@ -51,7 +51,11 @@ code-review *OPTIONS:
 
 # Run the test cases locally by nutest
 test:
-  @use $'($nu.default-config-dir)/lib/nutest' *; run-tests
+  @if not ('{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest", "nutest.nu") }}' | path exists) { \
+    print 'Cloning nutest ...'; \
+    git clone --depth 1 https://github.com/vyadh/nutest.git '{{ join(DEEPSEEK_REVIEW_PATH, "nutest") }}' \
+  }
+  @use '{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest", "nutest") }}' *; run-tests
 
 # Plugins need to be registered only once after nu v0.61
 _setup:


### PR DESCRIPTION
**Autoclone nutest repo**

Before: 
```
user@users-Mac-mini deepseek-review % just test
Error: nu::parser::module_not_found

  × Module not found.
   ╭─[source:1:5]
 1 │ use $'($nu.default-config-dir)/lib/nutest' *; run-tests
   ·     ───────────────────┬──────────────────
   ·                        ╰── module /Users/user/Library/Application Support/nushell/lib/nutest not found
   ╰────
  help: module files and their paths must be available before your script is run as parsing occurs before anything is evaluated

error: recipe `test` failed on line 54 with exit code 1
```

After:
```
user@users-Mac-mini deepseek-review % just test
Running tests...
Test run completed: 25 total, 25 passed, 0 failed, 0 skipped
```