### PR TITLE
fix(Justfile): replace deprecated register with plugin add in _setup recipe

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,19 @@ jobs:
         uses: hustcer/setup-nu@v3
         with:
           version: ${{ matrix.version }}
+        
+      - name: Setup Just
+        uses: extractions/setup-just@v4
+        with:
+          github-token: ${{ github.token }}
+          just-version: '*'
+
+      - name: Test Justfile
+        run: |
+          just --list
+          just cr --help
+          just release --help
+          just test
 
       - name: Test DeepSeek Review
         shell: nu {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,12 +58,14 @@ jobs:
           version: ${{ matrix.version }}
         
       - name: Setup Just
+        if: matrix.platform != 'macos-latest'
         uses: extractions/setup-just@v4
         with:
           github-token: ${{ github.token }}
           just-version: '*'
 
       - name: Test Justfile
+        if: matrix.platform != 'macos-latest'
         run: |
           just --list
           just cr --help

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 review.md
 config.yml
 prompts.yaml
+nutest/

--- a/Justfile
+++ b/Justfile
@@ -55,7 +55,7 @@ test:
     print 'Cloning nutest ...'; \
     git clone --depth 1 https://github.com/vyadh/nutest.git '{{ join(DEEPSEEK_REVIEW_PATH, "nutest") }}' \
   }
-  @use $'($nu.default-config-dir)/lib/nutest' *; run-tests --fail
+  @use '{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest") }}' *; run-tests --path '{{ join(DEEPSEEK_REVIEW_PATH, "tests") }}' --fail
 
 # Plugins need to be added only once; run `just _setup` to add nu_plugin_query
 _setup:

--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,6 @@ code-review *OPTIONS:
 test:
   @use $'($nu.default-config-dir)/lib/nutest' *; run-tests
 
-# Plugins need to be registered only once after nu v0.61
+# Plugins need to be added only once; run `just _setup` to add nu_plugin_query
 _setup:
-  @register -e json {{ join(NU_DIR, _query_plugin) }}
+  @plugin add {{ join(NU_DIR, _query_plugin) }}

--- a/Justfile
+++ b/Justfile
@@ -51,7 +51,11 @@ code-review *OPTIONS:
 
 # Run the test cases locally by nutest
 test:
-  @use $'($nu.default-config-dir)/lib/nutest' *; run-tests
+  @if not ('{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest", "mod.nu") }}' | path exists) { \
+    print 'Cloning nutest ...'; \
+    git clone --depth 1 https://github.com/vyadh/nutest.git '{{ join(DEEPSEEK_REVIEW_PATH, "nutest") }}' \
+  }
+  @use '{{ join(DEEPSEEK_REVIEW_PATH, "nutest", "nutest") }}' *; run-tests --path tests
 
 # Plugins need to be added only once; run `just _setup` to add nu_plugin_query
 _setup:

--- a/tests/test-stream-e2e.nu
+++ b/tests/test-stream-e2e.nu
@@ -169,8 +169,10 @@ def 'streaming：sends stream true and the configured model and prompts' [] {
   assert equal $payload.messages.0.content 'SYS-X'
   assert equal $payload.messages.1.role 'user'
   assert ($payload.messages.1.content | str starts-with 'USER-X')
-  # The diff itself has to reach the model, not just the prompt.
-  assert ($payload.messages.1.content | str contains 'diff --git')
+  # The diff itself has to reach the model, not just the prompt. `git show
+  # HEAD` emits a `diff --git` header for a normal commit but a combined
+  # `diff --cc` header when HEAD is a merge commit, so accept either.
+  assert (($payload.messages.1.content | str contains 'diff --git') or ($payload.messages.1.content | str contains 'diff --cc'))
 }
 
 @test


### PR DESCRIPTION
同时添加了Justfile测试工作流环节
相关：
- https://github.com/marketplace/actions/setup-just
- https://github.com/nushell/nushell/pull/13297
- https://github.com/nushell/nushell/pull/12607

#258依赖(且包含)于#257，若要合并应该先合并#257