### PR TITLE
feat: local code review for .patch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Flags:
   -f, --diff-from <string>: Git diff starting commit SHA
   -t, --diff-to <string>: Git diff ending commit SHA
   -c, --patch-cmd <string>: The `git show` or `git diff` command to get the diff content, for local CR only
-  -D, --diff-file <string>: Location of the diff file to review, for local CR only
+  -F, --patch-file <string>: Location of the patch file to review, for local CR only
   -l, --max-length <int>: Maximum length of the content for review, 0 means no limit.
   -m, --model <string>: Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   -b, --base-url <string>: DeepSeek API base URL, fallback to BASE_URL env var

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Flags:
   -f, --diff-from <string>: Git diff starting commit SHA
   -t, --diff-to <string>: Git diff ending commit SHA
   -c, --patch-cmd <string>: The `git show` or `git diff` command to get the diff content, for local CR only
+  -D, --diff-file <string>: Location of the diff file to review, for local CR only
   -l, --max-length <int>: Maximum length of the content for review, 0 means no limit.
   -m, --model <string>: Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   -b, --base-url <string>: DeepSeek API base URL, fallback to BASE_URL env var

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,6 +252,7 @@ Flags:
   -f, --diff-from <string>: Git diff starting commit SHA
   -t, --diff-to <string>: Git diff ending commit SHA
   -c, --patch-cmd <string>: The `git show` or `git diff` command to get the diff content, for local CR only
+  -D, --diff-file <string>: Location of the diff file to review, for local CR only
   -l, --max-length <int>: Maximum length of the content for review, 0 means no limit.
   -m, --model <string>: Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   -b, --base-url <string>: DeepSeek API base URL, fallback to BASE_URL env var

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,7 +252,7 @@ Flags:
   -f, --diff-from <string>: Git diff starting commit SHA
   -t, --diff-to <string>: Git diff ending commit SHA
   -c, --patch-cmd <string>: The `git show` or `git diff` command to get the diff content, for local CR only
-  -D, --diff-file <string>: Location of the diff file to review, for local CR only
+  -F, --patch-file <string>: Location of the patch file to review, for local CR only
   -l, --max-length <int>: Maximum length of the content for review, 0 means no limit.
   -m, --model <string>: Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   -b, --base-url <string>: DeepSeek API base URL, fallback to BASE_URL env var

--- a/cr
+++ b/cr
@@ -17,7 +17,7 @@ def main [
   --diff-from(-f): string,  # Git diff starting commit SHA
   --diff-to(-t): string,    # Git diff ending commit SHA
   --patch-cmd(-c): string,  # The `git show` or `git diff` command to get the diff content, for local CR only
-  --diff-file(-D): string,  # Location of the diff file to review, for local CR only
+  --patch-file(-F): string,  # Location of the patch file to review, for local CR only
   --max-length(-l): int,    # Maximum length of the content for review, 0 means no limit.
   --model(-m): string,      # Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   --base-url(-b): string,   # DeepSeek API base URL, fallback to BASE_URL env var
@@ -46,7 +46,7 @@ def main [
       --diff-to=$diff_to
       --diff-from=$diff_from
       --patch-cmd=$patch_cmd
-      --diff-file=$diff_file
+      --patch-file=$patch_file
       --pr-number=$pr_number
       --max-length=$max_length
       --sys-prompt=$sys_prompt

--- a/cr
+++ b/cr
@@ -17,6 +17,7 @@ def main [
   --diff-from(-f): string,  # Git diff starting commit SHA
   --diff-to(-t): string,    # Git diff ending commit SHA
   --patch-cmd(-c): string,  # The `git show` or `git diff` command to get the diff content, for local CR only
+  --diff-file(-D): string,  # Location of the diff file to review, for local CR only
   --max-length(-l): int,    # Maximum length of the content for review, 0 means no limit.
   --model(-m): string,      # Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   --base-url(-b): string,   # DeepSeek API base URL, fallback to BASE_URL env var
@@ -45,6 +46,7 @@ def main [
       --diff-to=$diff_to
       --diff-from=$diff_from
       --patch-cmd=$patch_cmd
+      --diff-file=$diff_file
       --pr-number=$pr_number
       --max-length=$max_length
       --sys-prompt=$sys_prompt

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -51,7 +51,16 @@ def get-diff-content [
   } else if ($diff_from | is-not-empty) {
     get-ref-diff $diff_from --diff-to $diff_to
   } else if ($diff_file | is-not-empty) {
-    open --raw $diff_file
+    let diff_path = if ($diff_file | str starts-with '/') {
+      $diff_file
+    } else {
+      $"($local_repo)/($diff_file)"
+    }
+    if not ($diff_path | path exists) {
+      print $'(ansi r)The diff file ($diff_path) does not exist, bye...(ansi reset)(char nl)'
+      exit $ECODE.CONDITION_NOT_SATISFIED
+    }
+    open --raw $diff_path
   } else if not (git-check $local_repo --check-repo=1) {
     print $'Current directory ($local_repo) is (ansi r)NOT(ansi reset) a git repo, bye...(char nl)'
     exit $ECODE.CONDITION_NOT_SATISFIED

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -50,7 +50,7 @@ def get-diff-content [
     get-pr-diff --repo $repo $pr_number
   } else if ($diff_from | is-not-empty) {
     get-ref-diff $diff_from --diff-to $diff_to
-  } else if ($diff-file | is-not-empty) {
+  } else if ($diff_file | is-not-empty) {
     open --raw $diff_file
   } else if not (git-check $local_repo --check-repo=1) {
     print $'Current directory ($local_repo) is (ansi r)NOT(ansi reset) a git repo, bye...(char nl)'

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -18,12 +18,12 @@ export def get-diff [
   --include: string,    # Comma separated file patterns to include in the code review
   --exclude: string,    # Comma separated file patterns to exclude in the code review
   --patch-cmd: string,  # The `git show` or `git diff` command to get the diff content
-  --diff-file: string,  # Location of the diff file to review
+  --patch-file: string,  # Location of the patch file to review
 ] {
   let content = (
     get-diff-content --repo $repo --pr-number $pr_number --patch-cmd $patch_cmd
       --diff-to $diff_to --diff-from $diff_from --include $include --exclude $exclude
-      --diff-file $diff_file)
+      --patch-file $patch_file)
 
   if ($content | is-empty) {
     print $'(ansi g)Nothing to review.(ansi reset)'
@@ -42,7 +42,7 @@ def get-diff-content [
   --include: string,    # Comma separated file patterns to include in the code review
   --exclude: string,    # Comma separated file patterns to exclude in the code review
   --patch-cmd: string,  # The `git show` or `git diff` command to get the diff content
-  --diff-file: string,  # Location of the diff file to review
+  --patch-file: string,  # Location of the patch file to review
 ] {
   let local_repo = $env.PWD
 
@@ -50,17 +50,17 @@ def get-diff-content [
     get-pr-diff --repo $repo $pr_number
   } else if ($diff_from | is-not-empty) {
     get-ref-diff $diff_from --diff-to $diff_to
-  } else if ($diff_file | is-not-empty) {
-    let diff_path = if ($diff_file | str starts-with '/') {
-      $diff_file
+  } else if ($patch_file | is-not-empty) {
+    let patch_path = if ($patch_file | str starts-with '/') {
+      $patch_file
     } else {
-      $"($local_repo)/($diff_file)"
+      $"($local_repo)/($patch_file)"
     }
-    if not ($diff_path | path exists) {
-      print $'(ansi r)The diff file ($diff_path) does not exist, bye...(ansi reset)(char nl)'
+    if not ($patch_path | path exists) {
+      print $'(ansi r)The patch file ($patch_path) does not exist, bye...(ansi reset)(char nl)'
       exit $ECODE.CONDITION_NOT_SATISFIED
     }
-    open --raw $diff_path
+    open --raw $patch_path
   } else if not (git-check $local_repo --check-repo=1) {
     print $'Current directory ($local_repo) is (ansi r)NOT(ansi reset) a git repo, bye...(char nl)'
     exit $ECODE.CONDITION_NOT_SATISFIED

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -18,6 +18,7 @@ export def get-diff [
   --include: string,    # Comma separated file patterns to include in the code review
   --exclude: string,    # Comma separated file patterns to exclude in the code review
   --patch-cmd: string,  # The `git show` or `git diff` command to get the diff content
+  --diff-file: string,  # Location of the diff file to review
 ] {
   let content = (
     get-diff-content --repo $repo --pr-number $pr_number --patch-cmd $patch_cmd
@@ -40,6 +41,7 @@ def get-diff-content [
   --include: string,    # Comma separated file patterns to include in the code review
   --exclude: string,    # Comma separated file patterns to exclude in the code review
   --patch-cmd: string,  # The `git show` or `git diff` command to get the diff content
+  --diff-file: string,  # Location of the diff file to review
 ] {
   let local_repo = $env.PWD
 
@@ -50,7 +52,7 @@ def get-diff-content [
   } else if not (git-check $local_repo --check-repo=1) {
     print $'Current directory ($local_repo) is (ansi r)NOT(ansi reset) a git repo, bye...(char nl)'
     exit $ECODE.CONDITION_NOT_SATISFIED
-  } else if ($patch_cmd | is-not-empty) {
+  } else if ($patch_cmd | is-not-empty) and ($diff-file | is-empty) {
     get-patch-diff $patch_cmd
   } else {
     git diff

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -51,16 +51,11 @@ def get-diff-content [
   } else if ($diff_from | is-not-empty) {
     get-ref-diff $diff_from --diff-to $diff_to
   } else if ($patch_file | is-not-empty) {
-    let patch_path = if ($patch_file | str starts-with '/') {
-      $patch_file
-    } else {
-      $"($local_repo)/($patch_file)"
-    }
-    if not ($patch_path | path exists) {
-      print $'(ansi r)The patch file ($patch_path) does not exist, bye...(ansi reset)(char nl)'
+    if not ($patch_file | path exists) {
+      print $'(ansi r)The patch file ($patch_file) does not exist, bye...(ansi reset)(char nl)'
       exit $ECODE.CONDITION_NOT_SATISFIED
     }
-    open --raw $patch_path
+    open --raw $patch_file
   } else if not (git-check $local_repo --check-repo=1) {
     print $'Current directory ($local_repo) is (ansi r)NOT(ansi reset) a git repo, bye...(char nl)'
     exit $ECODE.CONDITION_NOT_SATISFIED

--- a/nu/diff.nu
+++ b/nu/diff.nu
@@ -22,7 +22,8 @@ export def get-diff [
 ] {
   let content = (
     get-diff-content --repo $repo --pr-number $pr_number --patch-cmd $patch_cmd
-      --diff-to $diff_to --diff-from $diff_from --include $include --exclude $exclude)
+      --diff-to $diff_to --diff-from $diff_from --include $include --exclude $exclude
+      --diff-file $diff_file)
 
   if ($content | is-empty) {
     print $'(ansi g)Nothing to review.(ansi reset)'
@@ -49,10 +50,12 @@ def get-diff-content [
     get-pr-diff --repo $repo $pr_number
   } else if ($diff_from | is-not-empty) {
     get-ref-diff $diff_from --diff-to $diff_to
+  } else if ($diff-file | is-not-empty) {
+    open --raw $diff_file
   } else if not (git-check $local_repo --check-repo=1) {
     print $'Current directory ($local_repo) is (ansi r)NOT(ansi reset) a git repo, bye...(char nl)'
     exit $ECODE.CONDITION_NOT_SATISFIED
-  } else if ($patch_cmd | is-not-empty) and ($diff-file | is-empty) {
+  } else if ($patch_cmd | is-not-empty) {
     get-patch-diff $patch_cmd
   } else {
     git diff

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -127,7 +127,7 @@ export def --env deepseek-review [
   --diff-to(-t): string,    # Git diff ending commit SHA
   --diff-from(-f): string,  # Git diff starting commit SHA
   --patch-cmd(-c): string,  # The `git show` or `git diff` command to get the diff content, for local CR only
-  --diff-file(-D): string,  # Location of the diff file to review, for local CR only
+  --patch-file(-F): string,  # Location of the patch file to review, for local CR only
   --max-length(-l): int,    # Maximum length of the content for review, 0 means no limit.
   --model(-m): string,      # Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   --base-url(-b): string,   # DeepSeek API base URL, fallback to BASE_URL env var
@@ -166,7 +166,7 @@ export def --env deepseek-review [
     diff_to: $diff_to,
     diff_from: $diff_from,
     patch_cmd: $patch_cmd,
-    diff_file: $diff_file,
+    patch_file: $patch_file,
     pr_number: $pr_number,
     max_length: $max_length,
     local_repo: $local_repo,
@@ -194,7 +194,7 @@ export def --env deepseek-review [
   let content = (
     get-diff --pr-number $pr_number --repo $repo --diff-to $diff_to
              --diff-from $diff_from --include $include --exclude $exclude --patch-cmd $patch_cmd
-             --diff-file $diff_file)
+             --patch-file $patch_file)
   let length = $content | str stats | get unicode-width
   if ($max_length != 0) and ($length > $max_length) {
     print $'(char nl)(ansi r)The content length ($length) exceeds the maximum limit ($max_length), review skipped.(ansi reset)'

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -193,7 +193,8 @@ export def --env deepseek-review [
 
   let content = (
     get-diff --pr-number $pr_number --repo $repo --diff-to $diff_to
-             --diff-from $diff_from --include $include --exclude $exclude --patch-cmd $patch_cmd)
+             --diff-from $diff_from --include $include --exclude $exclude --patch-cmd $patch_cmd
+             --diff-file $diff_file)
   let length = $content | str stats | get unicode-width
   if ($max_length != 0) and ($length > $max_length) {
     print $'(char nl)(ansi r)The content length ($length) exceeds the maximum limit ($max_length), review skipped.(ansi reset)'

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -127,6 +127,7 @@ export def --env deepseek-review [
   --diff-to(-t): string,    # Git diff ending commit SHA
   --diff-from(-f): string,  # Git diff starting commit SHA
   --patch-cmd(-c): string,  # The `git show` or `git diff` command to get the diff content, for local CR only
+  --diff-file: string,      # Location of the diff file to review
   --max-length(-l): int,    # Maximum length of the content for review, 0 means no limit.
   --model(-m): string,      # Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   --base-url(-b): string,   # DeepSeek API base URL, fallback to BASE_URL env var
@@ -165,6 +166,7 @@ export def --env deepseek-review [
     diff_to: $diff_to,
     diff_from: $diff_from,
     patch_cmd: $patch_cmd,
+    diff_file: $diff_file,
     pr_number: $pr_number,
     max_length: $max_length,
     local_repo: $local_repo,

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -127,7 +127,7 @@ export def --env deepseek-review [
   --diff-to(-t): string,    # Git diff ending commit SHA
   --diff-from(-f): string,  # Git diff starting commit SHA
   --patch-cmd(-c): string,  # The `git show` or `git diff` command to get the diff content, for local CR only
-  --diff-file: string,      # Location of the diff file to review
+  --diff-file(-D): string,  # Location of the diff file to review, for local CR only
   --max-length(-l): int,    # Maximum length of the content for review, 0 means no limit.
   --model(-m): string,      # Model name, or read from CHAT_MODEL env var, `deepseek-v4-flash` by default
   --base-url(-b): string,   # DeepSeek API base URL, fallback to BASE_URL env var

--- a/tests/test-review.nu
+++ b/tests/test-review.nu
@@ -179,15 +179,15 @@ def 'get-diff：get patch from remote PR with exclude & include should work' [] 
 }
 
 @test
-def 'get-diff：should read diff from file with --diff-file' [] {
-  let content = get-diff --diff-file tests/resources/diff.patch
+def 'get-diff：should read patch from file with --patch-file' [] {
+  let content = get-diff --patch-file tests/resources/diff.patch
   assert ($content | is-not-empty)
   assert ($content | str contains 'diff --git')
 }
 
 @test
-def 'get-diff：--diff-file takes priority over --patch-cmd' [] {
-  let content = get-diff --diff-file tests/resources/diff.patch --patch-cmd 'git show HEAD'
+def 'get-diff：--patch-file takes priority over --patch-cmd' [] {
+  let content = get-diff --patch-file tests/resources/diff.patch --patch-cmd 'git show HEAD'
   assert ($content | is-not-empty)
   assert ($content | str contains 'diff --git')
 }

--- a/tests/test-review.nu
+++ b/tests/test-review.nu
@@ -177,3 +177,17 @@ def 'get-diff：get patch from remote PR with exclude & include should work' [] 
   let patch = get-diff --pr-number 93 --repo $repo --exclude **/*.yaml,*.md --include **/*.nu
   assert equal ($patch | get-uw) 2576
 }
+
+@test
+def 'get-diff：should read diff from file with --diff-file' [] {
+  let content = get-diff --diff-file tests/resources/diff.patch
+  assert ($content | is-not-empty)
+  assert ($content | str contains 'diff --git')
+}
+
+@test
+def 'get-diff：--diff-file takes priority over --patch-cmd' [] {
+  let content = get-diff --diff-file tests/resources/diff.patch --patch-cmd 'git show HEAD'
+  assert ($content | is-not-empty)
+  assert ($content | str contains 'diff --git')
+}


### PR DESCRIPTION
问题描述见: #141 
现在的优先级：PR > diff-from > patch-file > patch-cmd > git diff
测试已添加

**_Copilot summary:_**
This pull request adds support for specifying a patch file directly for code review, rather than only supporting diffs from git commands or PRs. The new `--patch-file` (or `-F`) flag is documented, implemented in the CLI and Nushell scripts, and tested to ensure it takes priority over other diff sources.

**New Patch File Support**

* Added a `--patch-file` (`-F`) flag to the CLI (`cr`), Nushell scripts (`nu/diff.nu`, `nu/review.nu`), and documentation (`README.md`, `README.zh-CN.md`) to allow specifying a patch file for review. [[1]](diffhunk://#diff-2b6bdfb2a0c30eaf5b7e128575ecc13354d74315c22edafa1141ea3445cefc5dR20) [[2]](diffhunk://#diff-8f3995aef815012056b48030e32b5354b01ac82ad95d0e37e4354b0c00c4e833R130) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R258) [[4]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987R255)
* Updated logic in `get-diff-content` to read from the patch file if provided, with validation for file existence and path handling.
* Ensured that `--patch-file` takes precedence over other diff options (e.g., `--patch-cmd`). [[1]](diffhunk://#diff-cd95584471ba1d525df41a342c95c46fe0f546f60df7717d9849dc9705d5bb31R21-R26) [[2]](diffhunk://#diff-2b6bdfb2a0c30eaf5b7e128575ecc13354d74315c22edafa1141ea3445cefc5dR49) [[3]](diffhunk://#diff-8f3995aef815012056b48030e32b5354b01ac82ad95d0e37e4354b0c00c4e833R169) [[4]](diffhunk://#diff-8f3995aef815012056b48030e32b5354b01ac82ad95d0e37e4354b0c00c4e833L194-R197)

**Testing**

* Added tests to verify reading from a patch file and that `--patch-file` overrides `--patch-cmd`.