### PR TITLE
feat: add --log-thinking option to write model thinking to a log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Add `--log-thinking` option to enable the model thinking and write it to a log file, disabled by default
+
 ## [1.21] - 2026-07-20
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ jobs:
   model: $model,
   stream: false,
   temperature: $temperature,
+  // `thinking` is enabled only when `--log-thinking` is passed, disabled by default
+  thinking: { type: 'disabled' },
   messages: [
     // `$sys_prompt` default value: You are a professional code review assistant responsible for
     // analyzing code changes in GitHub Pull Requests. Identify potential issues such as code
@@ -264,6 +266,7 @@ Flags:
   -i, --include <string>: Comma separated file patterns to include in the code review
   -x, --exclude <string>: Comma separated file patterns to exclude in the code review
   -T, --temperature <float>: Temperature for the model, between `0` and `2`, default value `0.3`
+  --log-thinking: Enable the model thinking and write it to a log file, disabled by default
   -C, --config <string>: Config file path, default to `config.yml`
   -o, --output <string>: Output file path
   -h, --help: Display the help message for this command

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -210,6 +210,8 @@ DeepSeek 接口调用入参:
   model: $model,
   stream: false,
   temperature: $temperature,
+  // 只有传入 `--log-thinking` 时才启用 thinking, 默认关闭
+  thinking: { type: 'disabled' },
   messages: [
     // `$sys_prompt` default value: You are a professional code review assistant responsible for
     // analyzing code changes in GitHub Pull Requests. Identify potential issues such as code
@@ -261,6 +263,7 @@ Flags:
   -i, --include <string>: Comma separated file patterns to include in the code review
   -x, --exclude <string>: Comma separated file patterns to exclude in the code review
   -T, --temperature <float>: Temperature for the model, between `0` and `2`, default value `0.3`
+  --log-thinking: 启用模型的思考并将思考内容写入日志文件，默认关闭
   -C, --config <string>: Config file path, default to `config.yml`
   -o, --output <string>: Output file path
   -h, --help: Display the help message for this command

--- a/config.example.yml
+++ b/config.example.yml
@@ -19,6 +19,10 @@ settings:
   max-length: 0
   # The temperature of the model, The value should be between 0 and 2, with default value 0.3
   temperature: 0.3
+  # Whether to enable the thinking of the model and write it to a log file
+  # Default value is false, thinking/reasoning is disabled by default
+  # When enabled, the reasoning content goes to a `<output>.thinking.log` file instead of the review result
+  log-thinking: false
   # The user prompt name to use for DeepSeek API select from 'prompts.user'
   user-prompt: 'default'
   # The system prompt name to use for DeepSeek API select from 'prompts.system'

--- a/cr
+++ b/cr
@@ -26,6 +26,7 @@ def main [
   --include(-i): string,    # Comma separated file patterns to include in the code review
   --exclude(-x): string,    # Comma separated file patterns to exclude in the code review
   --temperature(-T): float, # Temperature for the model, between `0` and `2`, default value `0.3`
+  --log-thinking: bool,     # Enable the model thinking and write it to a log file, disabled by default
   --config(-C): string      # Config file path, default to `config.yml`
   --output(-o): string,     # Output file path
 ] {
@@ -50,6 +51,7 @@ def main [
       --sys-prompt=$sys_prompt
       --user-prompt=$user_prompt
       --temperature=$temperature
+      --log-thinking=$log_thinking
       --include=($include | default $env.INCLUDE_PATTERNS?)
       --exclude=($exclude | default $env.EXCLUDE_PATTERNS?)
   )

--- a/nu/config.nu
+++ b/nu/config.nu
@@ -148,6 +148,7 @@ export def --env config-load [
     SYSTEM_PROMPT: $system_prompt,
     MAX_LENGTH: $settings.max-length,
     TEMPERATURE: $settings.temperature,
+    LOG_THINKING: $settings.log-thinking,
     GITHUB_TOKEN: $settings.github-token,
     EXCLUDE_PATTERNS: $settings.exclude-patterns,
     INCLUDE_PATTERNS: $settings.include-patterns,

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -136,6 +136,7 @@ export def --env deepseek-review [
   --include(-i): string,    # Comma separated file patterns to include in the code review
   --exclude(-x): string,    # Comma separated file patterns to exclude in the code review
   --temperature(-T): float, # Temperature for the model, between `0` and `2`, default value `0.3`
+  --log-thinking: bool,     # Enable the model thinking and write it to a log file, disabled by default
   --comment: string,       # Additional comment text from a PR comment mention trigger
 ]: nothing -> nothing {
 
@@ -152,6 +153,7 @@ export def --env deepseek-review [
   let url = $chat_url | default $env.CHAT_URL? | default $'($base_url)/chat/completions'
   let max_length = try { $max_length | default ($env.MAX_LENGTH? | default 0 | into int) } catch { 0 }
   let temperature = try { $temperature | default $env.TEMPERATURE? | default $DEFAULT_OPTIONS.TEMPERATURE | into float } catch { $DEFAULT_OPTIONS.TEMPERATURE }
+  let log_thinking = try { $log_thinking | default $env.LOG_THINKING? | default false | into bool } catch { false }
   # Determine output mode
   let output_mode = if $is_action { 'action' } else if ($output | is-not-empty) { 'file' } else { 'console' }
 
@@ -213,11 +215,11 @@ export def --env deepseek-review [
       { role: 'system', content: $sys_prompt },
       { role: 'user', content: $user_content }
     ],
-    thinking: { type: 'disabled' }
+    thinking: { type: (if $log_thinking { 'enabled' } else { 'disabled' }) }
   }
   if $debug { print $'(char nl)Code Changes:'; hr-line; print $content }
   print $'(char nl)Waiting for response from (ansi g)($url)(ansi reset) ...'
-  if $stream { streaming-output $url $payload --headers $CHAT_HEADER --debug=$debug; return }
+  if $stream { streaming-output $url $payload --headers $CHAT_HEADER --debug=$debug --log-thinking=$log_thinking; return }
 
   let response = http post -e -H $CHAT_HEADER -t application/json $url $payload
   if ($response | is-empty) {
@@ -232,12 +234,16 @@ export def --env deepseek-review [
   let message = $response | get -o choices.0.message
   let reason = $message | coalesce-reasoning
   let review = $message.content? | default ($response | get -o message.content)
-  let result = ['<details>' '<summary> Reasoning Details</summary>' $reason "</details>\n" $review] | str join "\n"
   if ($review | is-empty) {
     print $'✖️ Code review failed！No review result returned from ($base_url) ...'
     exit $ECODE.SERVER_ERROR
   }
-  let result = if ($reason | is-empty) { $review } else { $result }
+  let result = if $log_thinking {
+    if ($reason | is-not-empty) { write-thinking-log $reason $output }
+    $review
+  } else if ($reason | is-empty) { $review } else {
+    ['<details>' '<summary> Reasoning Details</summary>' $reason "</details>\n" $review] | str join "\n"
+  }
 
   match $output_mode {
     'action' => {
@@ -306,11 +312,13 @@ def streaming-output [
   url: string,        # The Full DeepSeek API URL
   payload: record,    # The payload to send to DeepSeek API
   --debug,            # Debug mode
+  --log-thinking: bool, # Whether to write the thinking/reasoning content to a log file
   --headers: list,    # The headers to send to DeepSeek API
 ] {
   print -n (char nl)
   kv set content 0
   kv set reasoning 0
+  if $log_thinking { kv set reasoning-content '' }
   http post -e -H $headers -t application/json $url $payload
     | tee {
         let res = $in
@@ -330,14 +338,27 @@ def streaming-output [
         if $debug { $last | to json | kv set last-reply }
         $last | get -o choices.0.delta | default ($last | get -o message) | if ($in | is-not-empty) {
           let delta = $in
-          if ($delta | coalesce-reasoning | is-not-empty) { kv set reasoning ((kv get reasoning) + 1) }
-          if (kv get reasoning) == 1 { print $'(char nl)Reasoning Details:'; hr-line }
-          if ($delta.content? | is-not-empty) { kv set content ((kv get content) + 1) }
+          let reason = $delta | coalesce-reasoning
+          let content = $delta.content? | default ''
+          if $log_thinking {
+            if ($reason | is-not-empty) { kv set reasoning-content ((kv get reasoning-content) + $reason) }
+          } else {
+            if ($reason | is-not-empty) { kv set reasoning ((kv get reasoning) + 1) }
+            if (kv get reasoning) == 1 { print $'(char nl)Reasoning Details:'; hr-line }
+          }
+          if ($content | is-not-empty) { kv set content ((kv get content) + 1) }
           if (kv get content) == 1 { print $'(char nl)Review Details:'; hr-line }
-          print -n ($delta | coalesce-reasoning | default ($delta.content? | default ''))
+          if $log_thinking {
+            if ($content | is-not-empty) { print -n $content }
+          } else {
+            print -n ($reason | default $content)
+          }
         }
       }
 
+  if $log_thinking and ((kv get reasoning-content | default '') | is-not-empty) {
+    write-thinking-log (kv get reasoning-content) ''
+  }
   if $debug and (kv get last-reply | is-not-empty) {
     print $'(char nl)(char nl)Model & Token Usage:'; hr-line
     kv get last-reply | from json | select -o model usage | table -e | print
@@ -364,6 +385,28 @@ def parse-line [] {
 def coalesce-reasoning [] {
   let msg = $in
   $msg.reasoning_content? | default $msg.reasoning?
+}
+
+# Write the thinking/reasoning content to a log file
+def write-thinking-log [content: string, output: string] {
+  let log_file = if ($output | is-not-empty) {
+    let stem = $output | str replace -r '\.md$' ''
+    $'($stem).thinking.log'
+  } else {
+    'thinking.log'
+  }
+  let sections = [
+    '# DeepSeek Thinking Log', ''
+    $"Generated at: (date now | format date '%Y/%m/%d %H:%M:%S')", ''
+    $content
+  ]
+  try {
+    ($sections | str join (char nl)) | save --force $log_file
+    print $'Thinking details saved to (ansi g)($log_file)(ansi reset)'
+  } catch {|err|
+    print $'(ansi r)Failed to save thinking log: (ansi reset)'
+    $err | table -e | print
+  }
 }
 
 alias main = deepseek-review


### PR DESCRIPTION
 - Summary — 新增 --log-thinking（默认关闭），启用模型 thinking 并把 reasoning 写入日志文件，不再混入审查结果
 - Motivation — 推理模型的 reasoning_content 目前会内嵌进审查输出（`<details>`）或流式打印，污染最终审查/PR
   评论；改为可单独留存
 - Behavior 表 — 默认路径与原来完全一致（thinking: {type: 'disabled'}）；开启后 thinking: {type: 'enabled'}，reasoning
   写 <output>.thinking.log（流式/控制台则 thinking.log）
 - 启用方式 — CLI --log-thinking / config log-thinking: true / env LOG_THINKING=true
 - Changes — 按文件列出
 - Validation — 默认行为不变；未做真实 API 测试（无 token），逻辑经代码审查 —— 如实说明，reviewer 心里有数
 - Checklist — 默认行为不变 / 文档更新 / 无破坏性变更