### PR TITLE
chore: set default temperature back to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ jobs:
 | max-length           | Int    | Optional, Maximum length (Unicode width) of the content for review. If the content length exceeds this value, the review will be skipped. Default `0` means no limit. |
 | sys-prompt           | String | Optional, System prompt corresponding to `$sys_prompt` in the payload, default value see note below                                                                   |
 | user-prompt          | String | Optional, User prompt corresponding to `$user_prompt` in the payload, default value see note below                                                                    |
-| temperature          | Number | Optional, The temperature for the model to generate the response, between `0` and `2`. Default value is `0.3`                                                         |
+| temperature          | Number | Optional, The temperature for the model to generate the response, between `0` and `2`. If not set, the temperature parameter is omitted and the provider's default is used                                    |
 | include-patterns     | String | Optional, Comma-separated file patterns to include in the code review. No default                                                                                     |
 | exclude-patterns     | String | Optional, Comma-separated file patterns to exclude from the code review. Defaults to `pnpm-lock.yaml,package-lock.json,*.lock`                                        |
 | github-token         | String | Optional, The `GITHUB_TOKEN` secret or personal access token to authenticate. Defaults to `${{ github.token }}`.                                                      |
@@ -211,6 +211,7 @@ jobs:
   // `$model` default value: deepseek-v4-flash
   model: $model,
   stream: false,
+  // `temperature` is omitted unless explicitly set (flag / TEMPERATURE env / config.yml); the provider default applies
   temperature: $temperature,
   messages: [
     // `$sys_prompt` default value: You are a professional code review assistant responsible for
@@ -263,7 +264,7 @@ Flags:
   -u, --user-prompt <string>: Default to $DEFAULT_OPTIONS.USER_PROMPT,
   -i, --include <string>: Comma separated file patterns to include in the code review
   -x, --exclude <string>: Comma separated file patterns to exclude in the code review
-  -T, --temperature <float>: Temperature for the model, between `0` and `2`, default value `0.3`
+  -T, --temperature <float>: Temperature for the model, between `0` and `2`, omitted and provider default is used when not set
   -C, --config <string>: Config file path, default to `config.yml`
   -o, --output <string>: Output file path
   -h, --help: Display the help message for this command

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,7 +195,7 @@ jobs:
 | max-length           | Int    | 可选，待审查内容的最大 Unicode 长度, 默认 `0` 表示没有限制，超过非零值则跳过审查                                  |
 | sys-prompt           | String | 可选，系统提示词对应入参中的 `$sys_prompt`, 默认值见后文注释                                                      |
 | user-prompt          | String | 可选，用户提示词对应入参中的 `$user_prompt`, 默认值见后文注释                                                     |
-| temperature          | Number | 可选，采样温度，介于 `0` 和 `2` 之间, 默认值 `0.3`                                                                |
+| temperature          | Number | 可选，采样温度，介于 `0` 和 `2` 之间；未设置时不传该参数，使用服务端默认值                                                                |
 | include-patterns     | String | 可选，代码审查中要包含的以逗号分隔的文件模式，无默认值                                                            |
 | exclude-patterns     | String | 可选，代码审查中要排除的以逗号分隔的文件模式，默认值为 `pnpm-lock.yaml,package-lock.json,*.lock`                  |
 | github-token         | String | 可选，用于访问 API 进行 PR 管理的 GitHub Token，默认为 `${{ github.token }}`                                      |
@@ -209,6 +209,7 @@ DeepSeek 接口调用入参:
   // `$model` default value: deepseek-v4-flash
   model: $model,
   stream: false,
+  // 未显式设置（flag / TEMPERATURE 环境变量 / config.yml）时不传 `temperature`, 使用服务端默认值
   temperature: $temperature,
   messages: [
     // `$sys_prompt` default value: You are a professional code review assistant responsible for
@@ -260,7 +261,7 @@ Flags:
   -u, --user-prompt <string>: Default to $DEFAULT_OPTIONS.USER_PROMPT,
   -i, --include <string>: Comma separated file patterns to include in the code review
   -x, --exclude <string>: Comma separated file patterns to exclude in the code review
-  -T, --temperature <float>: Temperature for the model, between `0` and `2`, default value `0.3`
+  -T, --temperature <float>: Temperature for the model, between `0` and `2`, omitted and provider default is used when not set
   -C, --config <string>: Config file path, default to `config.yml`
   -o, --output <string>: Output file path
   -h, --help: Display the help message for this command

--- a/action.yaml
+++ b/action.yaml
@@ -28,8 +28,7 @@ inputs:
     description: 'The DeepSeek model to choose for code review.'
   temperature:
     required: false
-    default: 0.3
-    description: 'The temperature of the model.'
+    description: 'The temperature of the model. If not set, the temperature parameter is omitted and the provider default is used.'
   base-url:
     required: false
     default: 'https://api.deepseek.com'
@@ -133,7 +132,7 @@ runs:
             --max-length (try { $env.MAX_LENGTH_INPUT | into int } catch { 0 })
             --sys-prompt $env.SYS_PROMPT_INPUT
             --user-prompt $env.USER_PROMPT_INPUT
-            --temperature (try { $env.TEMPERATURE_INPUT | into float } catch { 0.3 })
+            --temperature (try { $env.TEMPERATURE_INPUT | into float } catch { null })
             --include $env.INCLUDE_PATTERNS_INPUT
             --exclude $env.EXCLUDE_PATTERNS_INPUT
             --comment $env.COMMENT_BODY_INPUT

--- a/config.example.yml
+++ b/config.example.yml
@@ -17,8 +17,9 @@ settings:
   # If the content length exceeds the non-zero limit, the review will be skipped
   # Note that it's unicode width not LLM token length
   max-length: 0
-  # The temperature of the model, The value should be between 0 and 2, with default value 0.3
-  temperature: 0.3
+  # The temperature of the model, The value should be between 0 and 2
+  # If not set, the temperature parameter is omitted and the provider's default is used
+  # temperature: 1.0
   # The user prompt name to use for DeepSeek API select from 'prompts.user'
   user-prompt: 'default'
   # The system prompt name to use for DeepSeek API select from 'prompts.system'

--- a/cr
+++ b/cr
@@ -25,7 +25,7 @@ def main [
   --user-prompt(-u): string # Default to $DEFAULT_OPTIONS.USER_PROMPT,
   --include(-i): string,    # Comma separated file patterns to include in the code review
   --exclude(-x): string,    # Comma separated file patterns to exclude in the code review
-  --temperature(-T): float, # Temperature for the model, between `0` and `2`, default value `0.3`
+  --temperature(-T): float, # Temperature for the model, between `0` and `2`, omitted and provider default is used when not set
   --config(-C): string      # Config file path, default to `config.yml`
   --output(-o): string,     # Output file path
 ] {

--- a/nu/review.nu
+++ b/nu/review.nu
@@ -110,7 +110,6 @@ def is-pr-locked [
 
 const DEFAULT_OPTIONS = {
   MODEL: 'deepseek-v4-flash',
-  TEMPERATURE: 0.3,
   BASE_URL: 'https://api.deepseek.com',
   USER_PROMPT: 'Please review the following code changes:',
   SYS_PROMPT: 'You are a professional code review assistant responsible for analyzing code changes in GitHub Pull Requests. Identify potential issues such as code style violations, logical errors, security vulnerabilities, and provide improvement suggestions. Clearly list the problems and recommendations in a concise manner.',
@@ -135,7 +134,7 @@ export def --env deepseek-review [
   --user-prompt(-u): string # Default to $DEFAULT_OPTIONS.USER_PROMPT,
   --include(-i): string,    # Comma separated file patterns to include in the code review
   --exclude(-x): string,    # Comma separated file patterns to exclude in the code review
-  --temperature(-T): float, # Temperature for the model, between `0` and `2`, default value `0.3`
+  --temperature(-T): float, # Temperature for the model, between `0` and `2`, omitted and provider default is used when not set
   --comment: string,       # Additional comment text from a PR comment mention trigger
 ]: nothing -> nothing {
 
@@ -151,7 +150,9 @@ export def --env deepseek-review [
   let base_url = $base_url | default $env.BASE_URL? | default $DEFAULT_OPTIONS.BASE_URL
   let url = $chat_url | default $env.CHAT_URL? | default $'($base_url)/chat/completions'
   let max_length = try { $max_length | default ($env.MAX_LENGTH? | default 0 | into int) } catch { 0 }
-  let temperature = try { $temperature | default $env.TEMPERATURE? | default $DEFAULT_OPTIONS.TEMPERATURE | into float } catch { $DEFAULT_OPTIONS.TEMPERATURE }
+  # temperature is only set when explicitly specified via flag / TEMPERATURE env / config.yml,
+  # otherwise the payload omits the field and the provider's default applies
+  let temperature = try { $temperature | default $env.TEMPERATURE? | into float } catch { null }
   # Determine output mode
   let output_mode = if $is_action { 'action' } else if ($output | is-not-empty) { 'file' } else { 'console' }
 
@@ -208,13 +209,13 @@ export def --env deepseek-review [
   let payload = {
     model: $model,
     stream: $stream,
-    temperature: $temperature,
     messages: [
       { role: 'system', content: $sys_prompt },
       { role: 'user', content: $user_content }
     ],
     thinking: { type: 'disabled' }
   }
+  let payload = if $temperature == null { $payload } else { $payload | insert temperature $temperature }
   if $debug { print $'(char nl)Code Changes:'; hr-line; print $content }
   print $'(char nl)Waiting for response from (ansi g)($url)(ansi reset) ...'
   if $stream { streaming-output $url $payload --headers $CHAT_HEADER --debug=$debug; return }
@@ -293,7 +294,8 @@ def validate-token [token?: string, --pr-number: string, --repo: string] {
 }
 
 # Validate the temperature value
-def validate-temperature [temp: float] {
+def validate-temperature [temp?: float] {
+  if $temp == null { return }
   if ($temp < 0) or ($temp > 2) {
     print $'(ansi r)Invalid temperature value, should be in the range of 0 to 2.(ansi reset)'
     exit $ECODE.INVALID_PARAMETER

--- a/tests/test-review-internals.nu
+++ b/tests/test-review-internals.nu
@@ -179,7 +179,6 @@ def 'DEFAULT_OPTIONS：defaults stay in sync with action.yaml' [] {
   let inputs = open action.yaml | get inputs
   assert equal $DEFAULT_OPTIONS.MODEL $inputs.model.default
   assert equal $DEFAULT_OPTIONS.BASE_URL $inputs.base-url.default
-  assert equal $DEFAULT_OPTIONS.TEMPERATURE ($inputs.temperature.default | into float)
   assert equal $DEFAULT_OPTIONS.SYS_PROMPT $inputs.sys-prompt.default
 }
 


### PR DESCRIPTION
现代 LLM（DeepSeek V4、GPT-5、Claude 等）以 1.0 为中性默认采样温度，显式设置基本无效；0.3 反而误导且再也没有必要